### PR TITLE
Use PRODUCT_NAME env var for FastAPI title

### DIFF
--- a/major/src/major/server.py
+++ b/major/src/major/server.py
@@ -114,7 +114,8 @@ class SessionEventBus:
 event_bus = SessionEventBus()
 
 
-app = FastAPI(title="Major Chat Agent", version="0.1.0")
+product_name = os.environ.get("PRODUCT_NAME", "major")
+app = FastAPI(title=f"{product_name.title()} Agent", version="0.1.0")
 
 # CORS for local development
 app.add_middleware(


### PR DESCRIPTION
## Summary
- Uses `PRODUCT_NAME` env var to set FastAPI app title dynamically
- Allows distinguishing between products on the `/docs` page
- Defaults to "Major Agent" when env var is not set

## Test plan
- [ ] Verify `/docs` page shows correct product name when `PRODUCT_NAME` is set
- [ ] Verify default title works when env var is absent