### PR TITLE
Fix .chelle -> .combulate directory paths

### DIFF
--- a/major/src/major/server.py
+++ b/major/src/major/server.py
@@ -527,7 +527,7 @@ async def list_entity_types() -> list[EntityType]:
     types = []
 
     # Directories that are entity types (not hidden, not special)
-    skip_dirs = {'.git', '.claude', '.chelle', 'node_modules', '__pycache__', '.venv'}
+    skip_dirs = {'.git', '.claude', '.combulate', 'node_modules', '__pycache__', '.venv'}
 
     for item in workspace.iterdir():
         if item.is_dir() and item.name not in skip_dirs and not item.name.startswith('.'):

--- a/major/src/major/sessions.py
+++ b/major/src/major/sessions.py
@@ -5,7 +5,7 @@ SDK JSONL files are the source of truth for conversation history.
 Local metadata files store UI-specific data (title, archived, project, etc).
 
 Storage structure:
-    /opt/workspaces/{username}/{workspace}/.chelle/sessions.json
+    /opt/workspaces/{username}/{workspace}/.combulate/sessions.json
 
     {
         "session_id_1": {"title": "...", "archived": false, "project_id": null, ...},
@@ -60,7 +60,7 @@ class SessionManager:
 
     def _get_metadata_path(self, workspace_path: str) -> Path:
         """Get path to sessions.json for a workspace."""
-        return Path(workspace_path) / ".chelle" / "sessions.json"
+        return Path(workspace_path) / ".combulate" / "sessions.json"
 
     def _get_sdk_sessions_dir(self, workspace_path: str) -> Path:
         """Get SDK sessions directory for a workspace.
@@ -433,7 +433,7 @@ class SessionManager:
 
     def _get_pending_dir(self, workspace_path: str) -> Path:
         """Get path to pending messages directory."""
-        return Path(workspace_path) / ".chelle" / "pending"
+        return Path(workspace_path) / ".combulate" / "pending"
 
     def queue_pending_message(
         self,

--- a/major/src/major/worker.py
+++ b/major/src/major/worker.py
@@ -1,7 +1,7 @@
 """Major worker - processes pending messages from the file-based queue.
 
 Runs as a separate process alongside the API server in the same pod.
-Polls .chelle/pending/ for messages, processes them with MajorAgent,
+Polls .combulate/pending/ for messages, processes them with MajorAgent,
 and the SDK writes results to JSONL session files.
 """
 
@@ -142,7 +142,7 @@ async def process_message(
         ]
 
     # Process with agent — SDK writes to JSONL automatically
-    sessions_dir = Path(workspace_path) / ".chelle" / "sessions"
+    sessions_dir = Path(workspace_path) / ".combulate" / "sessions"
     async for event in agent.send_message(
         message=message,
         workspace_path=workspace_path,
@@ -184,7 +184,7 @@ async def worker_loop() -> None:
     config = MajorConfig()
     agent = MajorAgent(config=config)
 
-    logger.info(f"Major worker started, watching {workspace_path}/.chelle/pending/")
+    logger.info(f"Major worker started, watching {workspace_path}/.combulate/pending/")
 
     while True:
         pending = session_manager.get_next_pending(workspace_path)


### PR DESCRIPTION
## Summary
- Update sessions.py, worker.py, and server.py to use `.combulate/` instead of `.chelle/`
- The combulate entrypoint already migrated to `.combulate/` but Python code still referenced `.chelle/`

## Test plan
- [ ] Deploy and verify pending queue writes to `.combulate/pending/`
- [ ] Verify worker picks up messages from `.combulate/pending/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)